### PR TITLE
Bump Tycho version from 2.7.5 to 4.0.13

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
 	<packaging>pom</packaging>
 	
 	<properties>
+		<tycho.version>4.0.13</tycho.version>
+		<executionEnvironment>JavaSE-17</executionEnvironment>
 		<targetPlatform.relativePath>releng/org.palladiosimulator.architecturaltemplates.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	


### PR DESCRIPTION
Closes #32

Bump Tycho build from 2.7.5 to 4.0.13 to enable building on JDK 21. All bundle manifests already declare `Bundle-RequiredExecutionEnvironment: JavaSE-17`.

### Changes

- `.mvn/extensions.xml` – set Tycho extension version to 4.0.13
- `pom.xml` – add `<tycho.version>4.0.13</tycho.version>` and `<executionEnvironment>JavaSE-17</executionEnvironment>`

### See also

PR PalladioSimulator/Palladio-Addons-ExperimentAutomation#35 – the same migration applied to Palladio-Addons-ExperimentAutomation.