### PR TITLE
Migrate to parent POM version 0.11.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/bundles/org.palladiosimulator.architecturaltemplates/model/architecturaltemplates.genmodel
+++ b/bundles/org.palladiosimulator.architecturaltemplates/model/architecturaltemplates.genmodel
@@ -4,7 +4,7 @@
     modelPluginID="org.palladiosimulator.architecturaltemplates" modelName="Architecturaltemplates"
     rootExtendsInterface="org.eclipse.emf.cdo.CDOObject" rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl"
     rootImplementsInterface="" codeFormatting="true" importerID="org.eclipse.emf.importer.ecore"
-    featureDelegation="Dynamic" complianceLevel="8.0" copyrightFields="false" usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../org.modelversioning.emfprofile/model/emfprofiles.genmodel#//emfprofile ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.eclipse.ocl/model/OCL.genmodel#//ocl ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
+    featureDelegation="Dynamic" complianceLevel="17.0" copyrightFields="false" usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../org.modelversioning.emfprofile/model/emfprofiles.genmodel#//emfprofile ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.eclipse.ocl/model/OCL.genmodel#//ocl ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
     importOrganizing="true" cleanup="true">
   <foreignModel>architecturaltemplates.ecore</foreignModel>
   <modelPluginVariables>CDO=org.eclipse.emf.cdo</modelPluginVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.10.1</version>
+		<artifactId>repository-parent</artifactId>
+		<version>0.11.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.architecturaltemplates</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
 		<version>0.10.1</version>
+		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.architecturaltemplates</groupId>
 	<artifactId>parent</artifactId>	


### PR DESCRIPTION
- Add empty `<relativePath/>` to the parent POM to avoid Maven warnings about mismatched parent resolution.
- Update Tycho version in `.mvn/extensions.xml` to `4.0.13`.
- Set `complianceLevel` to `17.0` in `.genmodel` files.
- Migrate from parent POM `eclipse-parent-updatesite` version `0.10.1` to `repository-parent` version `0.11.0`.